### PR TITLE
fix: table naming convention to plural

### DIFF
--- a/database/migrations/2023_11_12_044000_create_waste_inventory_table.php
+++ b/database/migrations/2023_11_12_044000_create_waste_inventory_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('waste_inventory', function (Blueprint $table) {
+        Schema::create('waste_inventories', function (Blueprint $table) {
             $table->id();
             $table->string('name')->unique();
             $table->integer('amount');
@@ -24,6 +24,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('waste_inventory');
+        Schema::dropIfExists('waste_inventories');
     }
 };

--- a/database/migrations/2023_11_12_051541_create_recycled_waste_inventory_table.php
+++ b/database/migrations/2023_11_12_051541_create_recycled_waste_inventory_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('recycled_waste_inventory', function (Blueprint $table) {
+        Schema::create('recycled_waste_inventories', function (Blueprint $table) {
             $table->id();
             $table->string('name')->unique();
             $table->integer('amount');
@@ -24,6 +24,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('recycled_waste_inventory');
+        Schema::dropIfExists('recycled_waste_inventories');
     }
 };

--- a/database/migrations/2023_11_12_052309_create_waste_income_table.php
+++ b/database/migrations/2023_11_12_052309_create_waste_income_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('waste_income', function (Blueprint $table) {
+        Schema::create('waste_incomes', function (Blueprint $table) {
             $table->id();
             $table->decimal('cost', 10, 2);
             $table->integer('amount');
@@ -20,7 +20,7 @@ return new class extends Migration
             // Foreign key reference to employees table
             $table->foreignId('employee_id')->constrained('employees');
             // Foreign key reference to waste inventory table
-            $table->foreignId('waste_inventory_id')->constrained('waste_inventory');
+            $table->foreignId('waste_inventory_id')->constrained('waste_inventories');
             $table->timestamps();
         });
     }
@@ -30,6 +30,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('waste_income');
+        Schema::dropIfExists('waste_incomes');
     }
 };

--- a/database/migrations/2023_11_12_052936_create_conversions_table.php
+++ b/database/migrations/2023_11_12_052936_create_conversions_table.php
@@ -17,9 +17,9 @@ return new class extends Migration
             $table->integer('recycled_amount');
             $table->date('date');
             // Foreign key reference to waste inventory table
-            $table->foreignId('waste_inventory_id')->constrained('waste_inventory');
+            $table->foreignId('waste_inventory_id')->constrained('waste_inventories');
             // Foreign key reference to recycled waste inventory table
-            $table->foreignId('recycled_waste_inventory_id')->constrained('recycled_waste_inventory');
+            $table->foreignId('recycled_waste_inventory_id')->constrained('recycled_waste_inventories');
             // Foreign key reference to employees table
             $table->foreignId('employee_id')->constrained('employees');
             $table->timestamps();

--- a/database/migrations/2023_11_12_053149_create_sells_table.php
+++ b/database/migrations/2023_11_12_053149_create_sells_table.php
@@ -19,7 +19,7 @@ return new class extends Migration
             // Foreign key reference to employees table
             $table->foreignId('employee_id')->constrained('employees');
             // Foreign key reference to recycled waste inventory table
-            $table->foreignId('recycled_waste_inventory_id')->constrained('recycled_waste_inventory');
+            $table->foreignId('recycled_waste_inventory_id')->constrained('recycled_waste_inventories');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
✅ Updated database migration files naming convention for tables to plural instead of singular